### PR TITLE
Update Package.swift

### DIFF
--- a/websocket-chat/Package.swift
+++ b/websocket-chat/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", branch: "split-ws-client"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.2.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
     ],
     targets: [


### PR DESCRIPTION
HummingBird websocket dependency doesn't have 'split-ws-client' branch anymore.

so, when I build that example error occur.

Change package.swift

the websocket dependency can't find branch "split-ws-client". change dependency hummingbird-websocket.git branch "split-ws-client" to version "from 2.20"